### PR TITLE
 chore: update to `ya pkg add` for installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 > 
 > To install it with `ya` run:
 > ```sh
-> ya pack -a macydnah/office
+> ya pkg add macydnah/office
 > ```
 
 > Or if you prefer a manual approach:


### PR DESCRIPTION
 The `ya pack` command was deprecated in v25.5.28

see https://github.com/sxyazi/yazi/pull/2770

- Change `ya pack -a` installation command to `ya pkg add`