### PR TITLE
Add some more handling of `libreoffice` command output in case of failure

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -53,15 +53,16 @@ function M:doc2pdf(job)
 		})
 		:stdin(Command.NULL)
 		:stdout(Command.PIPED)
-		:stderr(Command.NULL)
+		:stderr(Command.PIPED)
 		:output()
 
 	if not libreoffice.status.success then
-		ya.err(
-			libreoffice.stdout:match("LibreOffice .+"):gsub("%\n.*", "")
-				.. " "
-				.. libreoffice.stdout:match("Error .+"):gsub("%\n.*", "")
-		)
+		local output = libreoffice.stdout .. libreoffice.stderr
+		local version = (output:match("LibreOffice .+") or ""):gsub("%\n.*", "")
+		local error = (output:match("Error:? .+") or ""):gsub("%\n.*", "")
+		if version ~= "" or error ~= "" then
+			ya.err((version or "LibreOffice") .. " " .. (error or "Unknown error"))
+		end
 		return nil, Err("Failed to preconvert `%s` to a temporary PDF", job.file.name)
 	end
 

--- a/main.lua
+++ b/main.lua
@@ -38,15 +38,7 @@ function M:doc2pdf(job)
 		:arg({
 			"--headless",
 			"--convert-to",
-			"pdf:draw_pdf_Export:{"
-				.. '"PageRange":{'
-				.. '"type":"string",'
-				.. '"value":'
-				.. '"'
-				.. job.skip + 1
-				.. '"'
-				.. "}"
-				.. "}",
+			'pdf:draw_pdf_Export:{"PageRange":{"type":"string","value":"' .. job.skip + 1 .. '"}}',
 			"--outdir",
 			tmp,
 			tostring(job.file.url),


### PR DESCRIPTION
I've noticed that sometimes, the `office` preloader tasks would fail with errors like the following:
```
Failed to run preloader `office`:
runtime error: ?:-1: attempt to index a nil value
stack traceback:
	?: in method 'doc2pdf'
	?: in function <?:78>
Failed to work on this task: runtime error: ?:-1: attempt to index a nil value
stack traceback:
	?: in method 'doc2pdf'
	?: in function <?:78>
```
After a bit of experimentation, I found that this seems to be coming from the output handling of the `libreoffice` command in the case of errors:
My version of LibreOffice (`25.8.1.1 580(Build:1)`) seems to be somewhat quiet, and not provide the keywords expected by the regular expressions, which causes `match()` to return `nil`, which in turn causes the `gsub()` call to fail.

It also seems like some errors are reported with a colon instead of a space after the `Error`, e.g. when trying to feeding a video file as input:
```
$ libreoffice --headless --convert-to 'pdf:draw_pdf_Export:{"PageRange":{"type":"string","value":"1"}}' --outdir /tmp/yazi-1000/ not-a-document.mkv
Error: source file could not be loaded
```