### PR TITLE
fix: use ya.emit and soffice for macOS compatibility

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -22,7 +22,7 @@ function M:seek(job)
 	local h = cx.active.current.hovered
 	if h and h.url == job.file.url then
 		local step = ya.clamp(-1, job.units, 1)
-		ya.manager_emit("peek", { math.max(0, cx.active.preview.skip + step), only_if = job.file.url })
+		ya.emit("peek", { math.max(0, cx.active.preview.skip + step), only_if = job.file.url })
 	end
 end
 
@@ -34,7 +34,7 @@ function M:doc2pdf(job)
 	  2. Always writes the converted files to the filesystem, so no "Mario|Bros|Piping|Magic" for the data stream (https://ask.libreoffice.org/t/using-convert-to-output-to-stdout/38753)
 	  3. The `pdf:draw_pdf_Export` filter needs literal double quotes when defining its options (https://help.libreoffice.org/latest/en-US/text/shared/guide/pdf_params.html?&DbPAR=SHARED&System=UNIX#generaltext/shared/guide/pdf_params.xhp)
 	  3.1 Regarding double quotes and Lua strings, see https://www.lua.org/manual/5.1/manual.html#2.1 --]]
-	local libreoffice = Command("libreoffice")
+	local libreoffice = Command("soffice")
 		:arg({
 			"--headless",
 			"--convert-to",
@@ -103,7 +103,7 @@ function M:preload(job)
 	elseif not output.status.success then
 		local pages = tonumber(output.stderr:match("the last page %((%d+)%)")) or 0
 		if job.skip > 0 and pages > 0 then
-			ya.mgr_emit("peek", { math.max(0, pages - 1), only_if = job.file.url, upper_bound = true })
+			ya.emit("peek", { math.max(0, pages - 1), only_if = job.file.url, upper_bound = true })
 		end
 		return true, Err("Failed to convert %s to image, stderr: %s", tmp_pdf, output.stderr)
 	end


### PR DESCRIPTION
## Summary
- Replace `ya.manager_emit` and `ya.mgr_emit` with `ya.emit` for yazi 25.x compatibility
- Use `soffice` instead of `libreoffice` command (required for macOS Homebrew)

## Test plan
- [x] Tested with yazi 25.x on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)